### PR TITLE
Linters: rustfmt + clippy in CI, fix all warnings, cleanup dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,19 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
+          components: rustfmt, clippy
+
+      - name: Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets -- --deny warnings
 
       - name: Build
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,10 @@ regex = "1.0.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0.121", features = ["derive"] }
 serde_json = "1.0"
-tempfile = "3.0"
 toml = "0.5.8"
-#tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3.0"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "https://github.com/francisco-perez-sorrosal/mdbook-bib" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     let matches = make_app().get_matches();
 
     // Users will want to construct their own preprocessor here
-    let preprocessor = mdbook_bib::Bibiography::new(); // Explicit Bibliography processor ref in lib.rs
+    let preprocessor = mdbook_bib::Bibiography::default(); // Explicit Bibliography processor ref in lib.rs
 
     if let Some(sub_args) = matches.subcommand_matches("supports") {
         handle_supports(&preprocessor, sub_args);


### PR DESCRIPTION
Here my first MR - added linters + some cleanup.

* Added [rustfmt](https://github.com/rust-lang/rustfmt) and [clippy](https://github.com/rust-lang/rust-clippy) to CI workflow `test`
* Fixed all clippy warnings
* Moved crate `tempfile` to section `dev-dependencies` of `Cargo.toml`, removed commented-out dep

No changes in functionality.