### PR TITLE
Allow to copy citations to clipboard from Bibliography

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod file_utils;
 static NAME: &str = "bib";
 static CSS: &str = include_str!("./render/satancisco.css");
 static BIBLIO_HB: &str = include_str!("./render/references.hbs");
+static CP2CB: &str = include_str!("./render/copy2clipboard.js");
 
 pub struct Bibiography;
 
@@ -118,8 +119,9 @@ impl Bibiography {
             "Creating new Bibliography chapter with content: {:?}",
             html_content
         );
+        let cp2cb = format!("<script type=\"text/javascript\">\n{}\n</script>\n\n", CP2CB); // Add the copy2clipboard js code
         let css_style = format!("<style>{}</style>\n\n", CSS); // Add the style css for the biblio
-        let biblio_content = format!("{}{}", css_style, html_content);
+        let biblio_content = format!("{}\n{}\n{}", cp2cb, css_style, html_content);
 
         Chapter::new(
             "Bibliography",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,10 @@ impl Bibiography {
             "Creating new Bibliography chapter with content: {:?}",
             html_content
         );
-        let cp2cb = format!("<script type=\"text/javascript\">\n{}\n</script>\n\n", CP2CB); // Add the copy2clipboard js code
+        let cp2cb = format!(
+            "<script type=\"text/javascript\">\n{}\n</script>\n\n",
+            CP2CB
+        ); // Add the copy2clipboard js code
         let css_style = format!("<style>{}</style>\n\n", CSS); // Add the style css for the biblio
         let biblio_content = format!("{}\n{}\n{}", cp2cb, css_style, html_content);
 

--- a/src/render/copy2clipboard.js
+++ b/src/render/copy2clipboard.js
@@ -1,4 +1,4 @@
-function oldCopyTextToClipboard(text) {
+function defaultCopyTextToClipboard(text) {
     var textArea = document.createElement("textarea");
     textArea.value = text;
 
@@ -24,7 +24,7 @@ function oldCopyTextToClipboard(text) {
 
 function copyToClipboard(text) {
     if (!navigator.clipboard) {
-        oldCopyTextToClipboard(text);
+        defaultCopyTextToClipboard(text);
         return;
     }
     navigator.clipboard.writeText(text).then(function() {

--- a/src/render/copy2clipboard.js
+++ b/src/render/copy2clipboard.js
@@ -1,0 +1,35 @@
+function oldCopyTextToClipboard(text) {
+    var textArea = document.createElement("textarea");
+    textArea.value = text;
+
+    // Avoid scrolling to bottom
+    textArea.style.top = "0";
+    textArea.style.left = "0";
+    textArea.style.position = "fixed";
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+        var ok = document.execCommand('copy');
+        var msg = ok ? 'was ok' : 'failed';
+        console.log('Backing copy: Text copy was ' + msg);
+    } catch (err) {
+        console.error('Backing copy: Unable to copy text', err);
+    }
+
+    document.body.removeChild(textArea);
+}
+
+function copyToClipboard(text) {
+    if (!navigator.clipboard) {
+        oldCopyTextToClipboard(text);
+        return;
+    }
+    navigator.clipboard.writeText(text).then(function() {
+        console.log('Text copied to clipboard');
+    }, function(err) {
+        console.error('Error copying text: ', err);
+    });
+}

--- a/src/render/references.hbs
+++ b/src/render/references.hbs
@@ -4,7 +4,8 @@
 <details data-key="{{citation_key}}" class=ref>
 {{!-- citation --}}
 <summary class=citation>
-<a id="{{citation_key}}">[{{citation_key}}]</a> - {{#if authors}}{{authors}} - {{/if}}{{#if title}}<cite>{{title}}</cite>.{{/if}} - {{#if pub_year}}{{pub_year}}.{{/if}}
+{{#if authors}}{{authors}} - {{/if}}{{#if title}}<cite>{{title}}</cite>.{{/if}} - {{#if pub_year}}{{pub_year}}.{{/if}} -
+<button onclick="copyToClipboard('\{\{ #cite {{citation_key}} \}\}')">Copy citation_key</button>
 </summary>
 {{!-- summary/abstract --}}
 {{#if summary}}
@@ -15,5 +16,7 @@
 {{/if}}
 </details>
 </div>
-<div class="hide">Citation key: {{citation_key}}</div>
+
 {{/if}}
+
+<br/>

--- a/src/render/references.hbs
+++ b/src/render/references.hbs
@@ -4,7 +4,7 @@
 <details data-key="{{citation_key}}" class=ref>
 {{!-- citation --}}
 <summary class=citation>
-{{#if authors}}{{authors}} - {{/if}}{{#if title}}<cite>{{title}}</cite>.{{/if}} - {{#if pub_year}}{{pub_year}}.{{/if}} -
+<a id="{{citation_key}}">[{{citation_key}}]</a> - {{#if authors}}{{authors}} - {{/if}}{{#if title}}<cite>{{title}}</cite>.{{/if}} - {{#if pub_year}}{{pub_year}}.{{/if}} -
 <button onclick="copyToClipboard('\{\{ #cite {{citation_key}} \}\}')">Copy citation_key</button>
 </summary>
 {{!-- summary/abstract --}}

--- a/src/render/satancisco.css
+++ b/src/render/satancisco.css
@@ -1,7 +1,0 @@
-.hide {
-    display: none;
-}
-.bib_div:hover + .hide {
-    display: block;
-    color: green;
-}


### PR DESCRIPTION
A button is shown in every bib entry to copy the citation key to the clipboard.
Also removes the popup citation key on hover mentioned in #2.

This should close #7 and #4