### PR TITLE
Refactor: Extract modules for improved architecture

### DIFF
--- a/src/citation/mod.rs
+++ b/src/citation/mod.rs
@@ -1,0 +1,211 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::path::{Component, Path};
+
+use handlebars::Handlebars;
+use indexmap::IndexMap;
+use lazy_static::lazy_static;
+use mdbook_preprocessor::book::{Book, BookItem, Chapter};
+use regex::Regex;
+
+use crate::config::SortOrder;
+use crate::models::{BibItem, Citation};
+use crate::renderer;
+
+static BIB_OUT_FILE: &str = "bibliography";
+
+// Regex patterns for citation placeholders
+// BibLaTeX-compliant character class for citation keys:
+// - Allowed: alphanumeric, underscore, hyphen, colon, dot, slash, at-symbol
+// - Forbidden: spaces, comma, quotes, hash, braces, percent, tilde, parentheses, equals
+pub const REF_PATTERN: &str = r"
+(?x)                       # insignificant whitespace mode
+\\\{\{\#.*\}\}               # match escaped placeholder
+|                            # or
+\{\{\s*                      # placeholder opening parens and whitespace
+\#cite                       # explicitly match #cite (only, not other mdBook helpers like #include, #title)
+\s+                          # separating whitespace
+([a-zA-Z0-9_\-:./@]+)        # citation key (capture group 1) - BibLaTeX compliant
+\s*\}\}                      # whitespace and placeholder closing parens";
+
+pub const AT_REF_PATTERN: &str = r##"(@@)([a-zA-Z0-9_\-/@]+(?:[.:][a-zA-Z0-9_\-/@]+)*)"##;
+
+lazy_static! {
+    static ref REF_REGEX: Regex = Regex::new(REF_PATTERN).unwrap();
+    static ref AT_REF_REGEX: Regex = Regex::new(AT_REF_PATTERN).unwrap();
+}
+
+/// Expand all citation references in the book, replacing placeholders with formatted citations.
+pub fn expand_cite_references_in_book(
+    book: &mut Book,
+    bibliography: &mut IndexMap<String, BibItem>,
+    handlebars: &Handlebars,
+) -> HashSet<String> {
+    let mut cited = HashSet::new();
+    let mut last_index = 0;
+    book.for_each_mut(|section: &mut BookItem| {
+        if let BookItem::Chapter(ref mut ch) = *section {
+            if let Some(ref chapter_path) = ch.path {
+                tracing::info!(
+                    "Replacing placeholders: {{{{#cite ...}}}} and @@citation in {}",
+                    chapter_path.as_path().display()
+                );
+                let new_content = replace_all_placeholders(
+                    ch,
+                    bibliography,
+                    &mut cited,
+                    handlebars,
+                    &mut last_index,
+                );
+                ch.content = new_content;
+            }
+        }
+    });
+    cited
+}
+
+/// Add bibliography at the end of each chapter.
+pub fn add_bib_at_end_of_chapters(
+    book: &mut Book,
+    bibliography: &mut IndexMap<String, BibItem>,
+    handlebars: &Handlebars,
+    order: SortOrder,
+) {
+    book.for_each_mut(|section: &mut BookItem| {
+        if let BookItem::Chapter(ref mut ch) = *section {
+            if let Some(ref chapter_path) = ch.path {
+                tracing::info!(
+                    "Adding bibliography at the end of chapter {}",
+                    chapter_path.as_path().display()
+                );
+
+                let mut cited = HashSet::new();
+                // Find all {{#cite ...}} keys
+                for caps in REF_REGEX.captures_iter(&ch.content) {
+                    if let Some(cite) = caps.get(1) {
+                        cited.insert(cite.as_str().trim().to_owned());
+                    }
+                }
+                // Find all @@... keys
+                for caps in AT_REF_REGEX.captures_iter(&ch.content) {
+                    if let Some(cite) = caps.get(2) {
+                        cited.insert(cite.as_str().trim().to_owned());
+                    }
+                }
+                tracing::info!("Refs cited in this chapter: {:?}", cited);
+
+                let ch_bib_header_html = handlebars
+                    .render("chapter_refs", &String::new())
+                    .unwrap()
+                    .as_str()
+                    .to_string();
+
+                let ch_bib_content_html = renderer::generate_bibliography_html(
+                    bibliography,
+                    &cited,
+                    true,
+                    handlebars,
+                    order.clone(),
+                );
+
+                let new_content = String::from(ch.content.as_str())
+                    + ch_bib_header_html.as_str()
+                    + ch_bib_content_html.as_str();
+                ch.content = new_content;
+            }
+        }
+    });
+}
+
+pub fn replace_all_placeholders(
+    chapter: &Chapter,
+    bibliography: &mut IndexMap<String, BibItem>,
+    cited: &mut HashSet<String>,
+    handlebars: &Handlebars,
+    last_index: &mut u32,
+) -> String {
+    let chapter_path = chapter.path.as_deref().unwrap_or_else(|| Path::new(""));
+
+    // Wrap mutable state in RefCell for interior mutability
+    let bib = RefCell::new(bibliography);
+    let cited_set = RefCell::new(cited);
+    let idx = RefCell::new(last_index);
+
+    // First replace all {{#cite ...}}
+    let replaced = REF_REGEX.replace_all(&chapter.content, |caps: &regex::Captures| {
+        let cite = caps.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+        cited_set.borrow_mut().insert(cite.to_owned());
+        let mut bib_mut = bib.borrow_mut();
+        let mut idx_mut = idx.borrow_mut();
+        if bib_mut.contains_key(cite) {
+            let path_to_root = breadcrumbs_up_to_root(chapter_path);
+            let item = bib_mut.get_mut(cite).unwrap();
+            if item.index.is_none() {
+                **idx_mut += 1;
+                item.index = Some(**idx_mut);
+            }
+            let citation = Citation {
+                item: item.clone(),
+                path: format!("{path_to_root}{BIB_OUT_FILE}.html"),
+            };
+            handlebars
+                .render("citation", &citation)
+                .unwrap()
+                .as_str()
+                .to_string()
+        } else {
+            format!("\\[Unknown bib ref: {cite}\\]")
+        }
+    });
+
+    // Then replace all @@cite
+    let replaced = AT_REF_REGEX.replace_all(&replaced, |caps: &regex::Captures| {
+        let cite = caps.get(2).map(|m| m.as_str().trim()).unwrap_or("");
+        cited_set.borrow_mut().insert(cite.to_owned());
+        let mut bib_mut = bib.borrow_mut();
+        let mut idx_mut = idx.borrow_mut();
+        if bib_mut.contains_key(cite) {
+            let path_to_root = breadcrumbs_up_to_root(chapter_path);
+            let item = bib_mut.get_mut(cite).unwrap();
+            if item.index.is_none() {
+                **idx_mut += 1;
+                item.index = Some(**idx_mut);
+            }
+            let citation = Citation {
+                item: item.clone(),
+                path: format!("{path_to_root}{BIB_OUT_FILE}.html"),
+            };
+            handlebars
+                .render("citation", &citation)
+                .unwrap()
+                .as_str()
+                .to_string()
+        } else {
+            format!("\\[Unknown bib ref: {cite}\\]")
+        }
+    });
+
+    replaced.into_owned()
+}
+
+fn breadcrumbs_up_to_root(source_file: &Path) -> String {
+    if source_file.as_os_str().is_empty() {
+        return String::new();
+    }
+
+    let components_count = source_file.components().fold(0, |acc, c| match c {
+        Component::Normal(_) => acc + 1,
+        Component::ParentDir => acc - 1,
+        Component::CurDir => acc,
+        Component::RootDir | Component::Prefix(_) => panic!(
+            "mdBook is not supposed to give us absolute paths, only relative from the book root."
+        ),
+    }) - 1;
+
+    let mut to_root = vec![".."; components_count].join("/");
+    if components_count > 0 {
+        to_root.push('/');
+    }
+
+    to_root
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,63 @@
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::anyhow;
+use mdbook_preprocessor::errors::{Error, Result as MdResult};
+use reqwest::blocking::Response;
+
+use crate::file_utils;
+
+/// Load bibliography from file.
+pub fn load_bibliography<P: AsRef<Path>>(biblio_file: P) -> MdResult<String> {
+    tracing::info!("Loading bibliography from {:?}...", biblio_file.as_ref());
+
+    let biblio_file_ext = file_utils::get_filename_extension(biblio_file.as_ref());
+    if biblio_file_ext.unwrap_or_default().to_lowercase() != "bib" {
+        tracing::warn!(
+            "Only biblatex-based bibliography is supported for now! Yours: {:?}",
+            biblio_file.as_ref()
+        );
+        return Ok(String::new());
+    }
+    Ok(fs::read_to_string(biblio_file)?)
+}
+
+/// Download bibliography from Zotero.
+pub fn download_bib_from_zotero(user_id: String) -> MdResult<String, Error> {
+    let mut url = format!("https://api.zotero.org/users/{user_id}/items?format=biblatex&style=biblatex&limit=100&sort=creator&v=3");
+    tracing::info!("Zotero's URL biblio source:\n{url:?}");
+    let mut res = reqwest::blocking::get(&url)?;
+    if res.status().is_client_error() || res.status().is_server_error() {
+        Err(anyhow!(format!(
+            "Error accessing Zotero API {:?}",
+            res.error_for_status()
+        )))
+    } else {
+        let (mut link_str, mut bib_content) = extract_biblio_data_and_link_info(&mut res);
+        while link_str.contains("next") {
+            // Extract next chunk URL
+            let next_idx = link_str.find("rel=\"next\"").unwrap();
+            let end_bytes = next_idx - 3; // The > of the "next" link is 3 chars before rel=\"next\" pattern
+            let slice = &link_str[..end_bytes];
+            let start_bytes = slice.rfind('<').unwrap_or(0);
+            url = link_str[(start_bytes + 1)..end_bytes].to_string();
+            tracing::info!("Next biblio chunk URL:\n{:?}", url);
+            res = reqwest::blocking::get(&url)?;
+            let (new_link_str, new_bib_part) = extract_biblio_data_and_link_info(&mut res);
+            link_str = new_link_str;
+            bib_content.push_str(&new_bib_part);
+        }
+        Ok(bib_content)
+    }
+}
+
+fn extract_biblio_data_and_link_info(res: &mut Response) -> (String, String) {
+    let mut biblio_chunk = String::new();
+    let _ = res.read_to_string(&mut biblio_chunk);
+    let link_info_in_header = res.headers().get("link");
+    tracing::debug!("Header Link content: {:?}", link_info_in_header);
+    let link_info_as_str = link_info_in_header.unwrap().to_str();
+
+    (link_info_as_str.unwrap().to_string(), biblio_chunk)
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+/// Bibliography item representation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BibItem {
+    /// The citation key.
+    pub citation_key: String,
+    /// The article's title.
+    pub title: String,
+    /// The article's author/s.
+    pub authors: Vec<Vec<String>>,
+    /// Pub month.
+    pub pub_month: String,
+    /// Pub year.
+    pub pub_year: String,
+    /// Summary/Abstract.
+    pub summary: String,
+    /// The article's url.
+    pub url: Option<String>,
+    /// The item's index for first citation in the book.
+    pub index: Option<u32>,
+}
+
+impl BibItem {
+    /// Create a new bib item with the provided content.
+    #[allow(dead_code)]
+    pub fn new(
+        citation_key: &str,
+        title: String,
+        authors: Vec<Vec<String>>,
+        pub_month: String,
+        pub_year: String,
+        summary: String,
+        url: Option<String>,
+    ) -> BibItem {
+        BibItem {
+            citation_key: citation_key.to_string(),
+            title,
+            authors,
+            pub_month,
+            pub_year,
+            summary,
+            url,
+            index: None,
+        }
+    }
+}
+
+/// Citation context for rendering.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Citation {
+    pub item: BibItem,
+    pub path: String,
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,215 @@
+use std::collections::HashMap;
+
+use anyhow::anyhow;
+use indexmap::IndexMap;
+use mdbook_preprocessor::errors::{Error, Result as MdResult};
+use nom_bibtex::Bibtex;
+use regex::Regex;
+
+use crate::models::BibItem;
+
+/// Parse bibliography content into a map of BibItems.
+pub fn parse_bibliography(raw_content: String) -> MdResult<IndexMap<String, BibItem>, Error> {
+    tracing::info!("Parsing bibliography...");
+
+    // Filter quotes (") that may appear in abstracts, etc. and that Bibtex parser doesn't like
+    let mut biblatex_content = raw_content.replace('\"', "");
+    // Expressions in the content such as R@10 are not parsed well
+    let re = Regex::new(r" (?P<before>[A-Za-z])@(?P<after>\d+) ").unwrap();
+    biblatex_content = re
+        .replace_all(&biblatex_content, " ${before}_at_${after} ")
+        .into_owned();
+
+    tracing::info!("Attempting to parse BibTeX content...");
+    let bib = match Bibtex::parse(&biblatex_content) {
+        Ok(bib) => {
+            tracing::info!("Successfully parsed BibTeX content");
+            bib
+        }
+        Err(e) => {
+            tracing::error!("Failed to parse BibTeX content: {}", e);
+            tracing::error!("This might be due to malformed BibTeX syntax, missing braces, or invalid characters");
+            return Err(anyhow!("BibTeX parsing failed: {e}"));
+        }
+    };
+
+    let biblio = bib.bibliographies();
+    tracing::info!("{} bibliography items read", biblio.len());
+
+    let bibliography: IndexMap<String, BibItem> = biblio
+        .iter()
+        .map(|bib| {
+            let citation_key = bib.citation_key().to_string();
+            tracing::info!("Processing bibliography entry: {}", citation_key);
+
+            let tm: HashMap<String, String> = bib
+                .tags()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            let authors_str = extract_authors(&tm, &citation_key);
+            let title = extract_title(&tm, &citation_key);
+            let summary = extract_summary(&tm, &citation_key);
+            let url = extract_url(&tm, &citation_key);
+            let (pub_year, pub_month) = extract_date(&tm, &citation_key);
+            let authors = parse_authors(&authors_str, &citation_key);
+
+            tracing::debug!(
+                "Entry {}: final authors list = '{:?}'",
+                citation_key,
+                authors
+            );
+
+            (
+                citation_key.clone(),
+                BibItem {
+                    citation_key,
+                    title,
+                    authors,
+                    pub_month,
+                    pub_year,
+                    summary,
+                    url,
+                    index: None,
+                },
+            )
+        })
+        .collect();
+
+    tracing::debug!("Bibliography content:\n{:?}", bibliography);
+    Ok(bibliography)
+}
+
+fn extract_authors(tm: &HashMap<String, String>, citation_key: &str) -> String {
+    match tm.get("author") {
+        Some(author) => {
+            let mut clean_author = author.to_string();
+            clean_author.retain(|c| c != '\n');
+            tracing::debug!("Entry {}: author field = '{}'", citation_key, clean_author);
+            clean_author
+        }
+        None => {
+            tracing::warn!("Entry {}: missing author field, using 'N/A'", citation_key);
+            "N/A".to_string()
+        }
+    }
+}
+
+fn extract_title(tm: &HashMap<String, String>, citation_key: &str) -> String {
+    match tm.get("title") {
+        Some(title_val) => {
+            tracing::debug!("Entry {}: title field = '{}'", citation_key, title_val);
+            title_val.to_string()
+        }
+        None => {
+            tracing::warn!(
+                "Entry {}: missing title field, using 'Not Found'",
+                citation_key
+            );
+            "Not Found".to_string()
+        }
+    }
+}
+
+fn extract_summary(tm: &HashMap<String, String>, citation_key: &str) -> String {
+    match tm.get("abstract") {
+        Some(abstract_val) => {
+            tracing::debug!(
+                "Entry {}: abstract field = '{}'",
+                citation_key,
+                abstract_val
+            );
+            abstract_val.to_string()
+        }
+        None => {
+            tracing::debug!(
+                "Entry {}: missing abstract field, using 'N/A'",
+                citation_key
+            );
+            "N/A".to_string()
+        }
+    }
+}
+
+fn extract_url(tm: &HashMap<String, String>, citation_key: &str) -> Option<String> {
+    match tm.get("url") {
+        Some(url_val) => match url_val.parse::<String>() {
+            Ok(parsed_url) => {
+                tracing::debug!("Entry {}: url field = '{}'", citation_key, parsed_url);
+                Some(parsed_url)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Entry {}: failed to parse URL '{}': {}",
+                    citation_key,
+                    url_val,
+                    e
+                );
+                None
+            }
+        },
+        None => {
+            tracing::debug!("Entry {}: missing url field", citation_key);
+            None
+        }
+    }
+}
+
+pub fn extract_date(tm: &HashMap<String, String>, citation_key: &str) -> (String, String) {
+    if let Some(date_str) = tm.get("date") {
+        tracing::debug!(
+            "Entry {}: Processing date field: '{}'",
+            citation_key,
+            date_str
+        );
+        let mut date = date_str.split('-');
+        let year = date.next().unwrap_or("N/A").to_string();
+        let month = date
+            .next()
+            .unwrap_or_else(|| tm.get("month").map(|s| s.as_str()).unwrap_or("N/A"))
+            .to_string();
+        tracing::debug!(
+            "Entry {}: Extracted from date field: year='{}', month='{}'",
+            citation_key,
+            year,
+            month
+        );
+        (year, month)
+    } else {
+        tracing::debug!(
+            "Entry {}: No date field found, looking for separate year/month fields",
+            citation_key
+        );
+        let year = tm
+            .get("year")
+            .map(|s| s.as_str())
+            .unwrap_or("N/A")
+            .to_string();
+        let month = tm
+            .get("month")
+            .map(|s| s.as_str())
+            .unwrap_or("N/A")
+            .to_string();
+        tracing::debug!(
+            "Entry {}: Extracted from separate fields: year='{}', month='{}'",
+            citation_key,
+            year,
+            month
+        );
+        (year, month)
+    }
+}
+
+fn parse_authors(authors_str: &str, citation_key: &str) -> Vec<Vec<String>> {
+    let and_split = Regex::new(r"\band\b").expect("Broken regex");
+    let splits = and_split.split(authors_str);
+    splits
+        .map(|a| {
+            let author_parts: Vec<String> =
+                a.trim().split(',').map(|b| b.trim().to_string()).collect();
+            tracing::debug!("Entry {}: author part = '{:?}'", citation_key, author_parts);
+            author_parts
+        })
+        .collect()
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,0 +1,57 @@
+use std::collections::HashSet;
+
+use handlebars::Handlebars;
+use indexmap::IndexMap;
+
+use crate::config::SortOrder;
+use crate::models::BibItem;
+
+/// Generate bibliography HTML from BibItems.
+pub fn generate_bibliography_html(
+    bibliography: &IndexMap<String, BibItem>,
+    cited: &HashSet<String>,
+    cited_only: bool,
+    handlebars: &Handlebars,
+    order: SortOrder,
+) -> String {
+    let sorted: Vec<(&str, &BibItem)> = match order {
+        SortOrder::None => bibliography.iter().map(|(k, v)| (k.as_str(), v)).collect(),
+        SortOrder::Key => {
+            let mut v: Vec<(&str, &BibItem)> =
+                bibliography.iter().map(|(k, v)| (k.as_str(), v)).collect();
+            v.sort_by_key(|item| item.0);
+            v
+        }
+        SortOrder::Author => {
+            let empty = "!".to_string();
+            let mut v: Vec<(&str, &BibItem)> =
+                bibliography.iter().map(|(k, v)| (k.as_str(), v)).collect();
+            v.sort_by_cached_key(|item| {
+                let val: &str = item
+                    .1
+                    .authors
+                    .first()
+                    .map(|vec| vec.first().unwrap_or(&empty))
+                    .unwrap_or(&empty);
+                val
+            });
+            v
+        }
+        SortOrder::Index => {
+            let mut v: Vec<(&str, &BibItem)> =
+                bibliography.iter().map(|(k, v)| (k.as_str(), v)).collect();
+            v.sort_by_key(|item| item.1.index);
+            v
+        }
+    };
+
+    let mut content = String::new();
+    for (key, value) in sorted {
+        if !cited_only || cited.contains(key) {
+            content.push_str(handlebars.render("references", &value).unwrap().as_str());
+        }
+    }
+
+    tracing::debug!("Generated Bib Content: {:?}", content);
+    content
+}


### PR DESCRIPTION
Extract code from lib.rs into dedicated modules to improve maintainability:

- models/: BibItem and Citation data structures
- parser/: Bibliography parsing logic (nom-bibtex)
- renderer/: HTML generation from BibItems
- citation/: Citation replacement and per-chapter bibliography
- io/: File loading and Zotero download operations

Benefits:
- Reduced lib.rs from 770 lines to 202 lines (73% reduction)
- Clear separation of concerns with single responsibility per module
- Improved testability through proper module boundaries
- Zero functionality changes - all tests pass, builds successful
- Prepared architecture for backend abstraction

All 17 tests pass. No breaking changes to user-facing functionality.

This aims to close #63 