### PR TITLE
Enhance Makefile and documentation for improved release management

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,11 @@
       "Bash(pandoc:*)",
       "Bash(mdbook:*)",
       "Bash(git checkout:*)",
-      "Bash(xargs:*)"
+      "Bash(xargs:*)",
+      "Bash(make release-dry-run:*)",
+      "Bash(make help:*)",
+      "Bash(make release:*)",
+      "Bash(make update-cargo:*)"
     ]
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,62 +1,109 @@
 # Makefile for mdbook-bib version management
 
-.PHONY: help update-version update-cargo update-doc release
+.PHONY: help update-version update-cargo update-doc release show-version
+
+# Get current version from Cargo.toml
+CURRENT_VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+# Auto-increment patch version if VERSION not specified
+# Splits x.y.z and increments z
+ifndef VERSION
+  VERSION_MAJOR := $(word 1,$(subst ., ,$(CURRENT_VERSION)))
+  VERSION_MINOR := $(word 2,$(subst ., ,$(CURRENT_VERSION)))
+  VERSION_PATCH := $(word 3,$(subst ., ,$(CURRENT_VERSION)))
+  NEXT_PATCH := $(shell echo $$(($(VERSION_PATCH) + 1)))
+  VERSION := $(VERSION_MAJOR).$(VERSION_MINOR).$(NEXT_PATCH)
+  AUTO_VERSION := 1
+endif
+
+# Dry-run support: set DRY_RUN=1 to simulate commands
+ifdef DRY_RUN
+  RUN := @echo "[DRY-RUN]"
+  DRY_RUN_MSG := (DRY-RUN)
+else
+  RUN := @
+  DRY_RUN_MSG :=
+endif
 
 # Default target
 help:
-	@echo "Available targets:"
-	@echo "  update-version VERSION=x.y.z  - Update version in both Cargo.toml and doc.yml"
-	@echo "  update-cargo VERSION=x.y.z    - Update version only in Cargo.toml"
-	@echo "  update-doc VERSION=x.y.z      - Update version only in doc.yml"
-	@echo "  release VERSION=x.y.z         - Complete release process (update, commit, tag, push)"
-	@echo "  help                          - Show this help message"
+	@echo "mdbook-bib Release Management"
+	@echo "=============================="
+	@echo ""
+	@echo "Current version: $(CURRENT_VERSION)"
+	@echo "Next version:    $(VERSION) (auto-incremented patch)"
+	@echo ""
+	@echo "Targets:"
+	@echo "  show-version                  - Show current and next version"
+	@echo "  update-version                - Update version in Cargo.toml and doc.yml"
+	@echo "  update-cargo                  - Update version only in Cargo.toml"
+	@echo "  update-doc                    - Update version only in doc.yml"
+	@echo "  release                       - Complete release (update, commit, tag, push)"
+	@echo ""
+	@echo "Options:"
+	@echo "  VERSION=x.y.z                 - Specify version (default: auto-increment patch)"
+	@echo "  DRY_RUN=1                     - Simulate without making changes"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make update-version VERSION=0.0.8"
-	@echo "  make update-cargo VERSION=0.0.8"
-	@echo "  make update-doc VERSION=0.0.8"
-	@echo "  make release VERSION=0.0.8"
+	@echo "  make release                      # Release $(VERSION) (auto)"
+	@echo "  make release VERSION=1.0.0        # Release specific version"
+	@echo "  make release DRY_RUN=1            # Simulate release $(VERSION)"
+	@echo "  make update-version DRY_RUN=1     # Simulate version update"
+
+# Show current and computed next version
+show-version:
+	@echo "Current version: $(CURRENT_VERSION)"
+	@echo "Next version:    $(VERSION)"
+ifdef AUTO_VERSION
+	@echo "(auto-incremented from $(CURRENT_VERSION))"
+endif
 
 # Main target to update version in both files
 update-version: update-cargo update-doc
-	@echo "Version updated to $(VERSION) in both Cargo.toml and doc.yml"
+	@echo "$(DRY_RUN_MSG)✓ Version updated to $(VERSION) in both Cargo.toml and doc.yml"
 
 # Update version in Cargo.toml
 update-cargo:
-	@if [ -z "$(VERSION)" ]; then \
-		echo "Error: VERSION parameter is required. Use: make update-cargo VERSION=x.y.z"; \
-		exit 1; \
-	fi
-	@echo "Updating version to $(VERSION) in Cargo.toml..."
+	@echo "$(DRY_RUN_MSG)Updating version to $(VERSION) in Cargo.toml..."
+ifdef DRY_RUN
+	@echo "[DRY-RUN] sed -i.bak 's/^version = \".*\"/version = \"$(VERSION)\"/' Cargo.toml"
+	@echo "[DRY-RUN] Current: version = \"$(CURRENT_VERSION)\""
+	@echo "[DRY-RUN] New:     version = \"$(VERSION)\""
+else
 	@sed -i.bak 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml
 	@rm -f Cargo.toml.bak
-	@echo "✓ Cargo.toml updated"
+endif
+	@echo "$(DRY_RUN_MSG)✓ Cargo.toml updated"
 
 # Update version in doc.yml
 update-doc:
-	@if [ -z "$(VERSION)" ]; then \
-		echo "Error: VERSION parameter is required. Use: make update-doc VERSION=x.y.z"; \
-		exit 1; \
-	fi
-	@echo "Updating MDBOOK_BIB_VERSION to $(VERSION) in .github/workflows/doc.yml..."
+	@echo "$(DRY_RUN_MSG)Updating MDBOOK_BIB_VERSION to $(VERSION) in doc.yml..."
+ifdef DRY_RUN
+	@echo "[DRY-RUN] sed -i.bak 's/MDBOOK_BIB_VERSION: .*/MDBOOK_BIB_VERSION: $(VERSION)/' .github/workflows/doc.yml"
+	@echo "[DRY-RUN] Current: $$(grep 'MDBOOK_BIB_VERSION:' .github/workflows/doc.yml | head -1)"
+else
 	@sed -i.bak 's/^\([[:space:]]*MDBOOK_BIB_VERSION: \).*/\1$(VERSION)/' .github/workflows/doc.yml
 	@rm -f .github/workflows/doc.yml.bak
-	@echo "✓ doc.yml updated"
+endif
+	@echo "$(DRY_RUN_MSG)✓ doc.yml updated"
 
-# Complete release process: update version, commit changes, create and push tag
+# Complete release process
 release: update-version
-	@if [ -z "$(VERSION)" ]; then \
-		echo "Error: VERSION parameter is required. Use: make release VERSION=x.y.z"; \
-		exit 1; \
-	fi
-	@echo "Starting release process for version $(VERSION)..."
-	@echo "Adding changes to git..."
-	@git add Cargo.toml .github/workflows/doc.yml
-	@echo "Committing changes..."
-	@git commit -m "Prepare for release v$(VERSION)"
-	@echo "Creating tag v$(VERSION)..."
-	@git tag -a v$(VERSION) -m "Version v$(VERSION)"
-	@echo "Pushing commit and tag to origin..."
-	@git push origin master
-	@git push origin v$(VERSION)
-	@echo "✓ Release v$(VERSION) completed successfully!" 
+	@echo ""
+	@echo "$(DRY_RUN_MSG)Starting release process for version $(VERSION)..."
+	@echo ""
+	@echo "$(DRY_RUN_MSG)[1/4] Staging changes..."
+	$(RUN) git add Cargo.toml .github/workflows/doc.yml
+	@echo "$(DRY_RUN_MSG)[2/4] Committing..."
+	$(RUN) git commit -m "Prepare for release v$(VERSION)"
+	@echo "$(DRY_RUN_MSG)[3/4] Creating tag v$(VERSION)..."
+	$(RUN) git tag -a v$(VERSION) -m "Version v$(VERSION)"
+	@echo "$(DRY_RUN_MSG)[4/4] Pushing to origin..."
+	$(RUN) git push origin master
+	$(RUN) git push origin v$(VERSION)
+	@echo ""
+	@echo "$(DRY_RUN_MSG)✓ Release v$(VERSION) completed!"
+ifdef DRY_RUN
+	@echo ""
+	@echo "Run 'make release' or 'make release VERSION=$(VERSION)' to execute for real."
+endif

--- a/manual/src/dev.md
+++ b/manual/src/dev.md
@@ -49,18 +49,69 @@ After successful test pass, the `CHANGELOG.md` is updated.
 
 ## Release
 
-The release process can be triggered with the `make` command `make release VERSION=0.0.7` and it's composed by:
+The release process is managed via `make`. Run `make help` to see all options:
 
-- Update new version (e.g. 0.0.7) in `Cargo.toml`, and `doc.yml` in the github workflows
-- Do a commit with those changes with a message like `Prepare for release v0.0.7`
-- Pull the remote changes to get the updated CHANGELOG.md by the previous commit from github: `git pull origin master`
-- The release will be triggered by:
-  - Creating a new tag in github: `git tag -a v0.0.7 -m "Version v0.0.7"`
-  - Pushing the tag to github: `git push origin v0.0.7`
-- The release will exercise the github workflows:
-  - `publish.yml` - Publish the release
-  - `releaese.yml` - Create the binary packages to release in [here](https://github.com/francisco-perez-sorrosal/mdbook-bib/releases)
-  - `doc.yml`  - Will publish the book with this instructions [here](https://francisco-perez-sorrosal.github.io/mdbook-bib/)
+```sh
+make help
+```
+
+### Quick Release
+
+To release the next patch version (auto-incremented):
+
+```sh
+make release              # Releases 0.5.1 → 0.5.2 automatically
+```
+
+To release a specific version:
+
+```sh
+make release VERSION=1.0.0
+```
+
+### Dry-Run Mode
+
+Add `DRY_RUN=1` to any command to simulate without making changes:
+
+```sh
+make release DRY_RUN=1              # Simulate with auto-version
+make release DRY_RUN=1 VERSION=1.0.0  # Simulate specific version
+make update-cargo DRY_RUN=1         # Simulate just Cargo.toml update
+```
+
+### Available Targets
+
+| Target | Description |
+|--------|-------------|
+| `release` | Complete release (update, commit, tag, push) |
+| `update-version` | Update version in Cargo.toml and doc.yml |
+| `update-cargo` | Update version only in Cargo.toml |
+| `update-doc` | Update version only in doc.yml |
+| `show-version` | Show current and next version |
+
+### Release Steps
+
+The release process performs these steps:
+
+1. Update version in `Cargo.toml` and `.github/workflows/doc.yml`
+2. Commit changes with message `Prepare for release vX.Y.Z`
+3. Create annotated tag `vX.Y.Z`
+4. Push commit and tag to origin
+
+After pushing, pull remote changes to get the updated CHANGELOG.md:
+
+```sh
+git pull origin master
+```
+
+### GitHub Workflows Triggered
+
+The tag push triggers these workflows:
+
+- `publish.yml` - Publishes to crates.io
+- `release.yml` - Creates binary packages in [Releases](https://github.com/francisco-perez-sorrosal/mdbook-bib/releases)
+- `doc.yml` - Publishes documentation to [GitHub Pages](https://francisco-perez-sorrosal.github.io/mdbook-bib/)
 
 ## ToDo
+
 Improve the process above when bored or when you want to improve friction points (e.g. the Changelog is updated post release, etc.)


### PR DESCRIPTION
- Updated Makefile to include a dry-run mode for simulating commands without changes.
- Added a new target `show-version` to display current and next version information.
- Improved help output in Makefile to clarify available targets and options.
- Enhanced documentation in `dev.md` to detail the release process, including quick release commands and dry-run usage.
- Updated settings for local development to include new make commands for better integration.

This aims to close #67