### PR TITLE
fix(citation): clean up REF_PATTERN

### DIFF
--- a/src/citation/mod.rs
+++ b/src/citation/mod.rs
@@ -45,10 +45,7 @@ const CODE_BLOCK_PLACEHOLDER: &str = "\u{E000}MDBIB_CODEBLOCK";
 // BibLaTeX-compliant character class for citation keys:
 // - Allowed: alphanumeric, underscore, hyphen, colon, dot, slash, at-symbol
 // - Forbidden: spaces, comma, quotes, hash, braces, percent, tilde, parentheses, equals
-pub const REF_PATTERN: &str = r"
-(?x)                       # insignificant whitespace mode
-\\\{\{\#.*\}\}               # match escaped placeholder
-|                            # or
+pub const REF_PATTERN: &str = r"(?x) # enable insignificant whitespace mode + in-regex comments
 \{\{\s*                      # placeholder opening parens and whitespace
 \#cite                       # explicitly match #cite (only, not other mdBook helpers like #include, #title)
 \s+                          # separating whitespace


### PR DESCRIPTION
The REF_PATTERN was matching any and all escaped mdbook directives preceded by a newline (i.e. \{{#huh}}). The original pattern had incorrectly placed the whitespace escape flag after a newline character, which meant that the newline coming before it also had to be matched.

Making the flag the actual first text in the regex pattern allows us to remove the somewhat nonsensical part of the regex so that it actually reflects the thing we're trying to match.

To compare, the new pattern looks like this:

```
(?x) # enable insignificant whitespace mode + in-regex comments
\{\{\s*                      # placeholder opening parens and whitespace
\#cite                       # explicitly match #cite (only, not other mdBook helpers like #include, #title)
\s+                          # separating whitespace
([a-zA-Z0-9_\-:./@]+)        # citation key (capture group 1) - BibLaTeX compliant, allows digit start
\s*\}\}                      # whitespace and placeholder closing parens
```

versus the original (note the newline at the start):

```

(?x)                       # insignificant whitespace mode
\\\{\{\#.*\}\}               # match escaped placeholder
|                            # or
\{\{\s*                      # placeholder opening parens and whitespace
\#cite                       # explicitly match #cite (only, not other mdBook helpers like #include, #title)
\s+                          # separating whitespace
([a-zA-Z0-9_\-:./@]+)        # citation key (capture group 1) - BibLaTeX compliant, allows digit start
\s*\}\}                      # whitespace and placeholder closing parens
```