### PR TITLE
misc: reduce logging verbosity

### DIFF
--- a/src/backend/csl.rs
+++ b/src/backend/csl.rs
@@ -60,7 +60,7 @@ impl CslBackend {
     /// The backend includes 80+ bundled styles from the hayagriva archive.
     /// Use `supported_style_aliases()` to list common aliases.
     pub fn new(style_name: String) -> anyhow::Result<Self> {
-        tracing::info!("Initializing CSL backend with style: {}", style_name);
+        tracing::debug!("Initializing CSL backend with style: {}", style_name);
 
         // Look up in registry first (provides aliases), then fall back to hayagriva's by_name
         let style_info = find_style_info(&style_name);
@@ -69,7 +69,7 @@ impl CslBackend {
         // Detect format from CSL metadata (used as fallback when not in registry)
         let detected_format = detect_style_format(&style);
         if resolved_info.is_none() {
-            tracing::info!(
+            tracing::warn!(
                 "Style '{}' not in registry, detected format: {:?}",
                 style_name,
                 detected_format.citation_format()
@@ -78,7 +78,7 @@ impl CslBackend {
 
         let locales = locales();
 
-        tracing::info!(
+        tracing::debug!(
             "CSL backend initialized successfully with style '{}'",
             style_name
         );

--- a/src/citation/mod.rs
+++ b/src/citation/mod.rs
@@ -165,7 +165,7 @@ pub fn expand_cite_references_in_book(
     book.for_each_mut(|section: &mut BookItem| {
         if let BookItem::Chapter(ref mut ch) = *section {
             if let Some(ref chapter_path) = ch.path {
-                tracing::info!(
+                tracing::debug!(
                     "Replacing placeholders: {} in {}",
                     syntax_info,
                     chapter_path.as_path().display()
@@ -211,15 +211,15 @@ pub fn add_bib_at_end_of_chapters(
                     .unwrap_or_default();
 
                 if cited.is_empty() {
-                    tracing::info!(
+                    tracing::debug!(
                         "No citations in chapter {}, skipping bibliography",
                         chapter_key
                     );
                     return;
                 }
 
-                tracing::info!("Adding bibliography at the end of chapter {}", chapter_key);
-                tracing::info!("Refs cited in this chapter: {:?}", cited);
+                tracing::debug!("Adding bibliography at the end of chapter {}", chapter_key);
+                tracing::debug!("Refs cited in this chapter: {:?}", cited);
 
                 let ch_bib_content_html = renderer::generate_bibliography_html(
                     bibliography,
@@ -285,7 +285,7 @@ fn replace_citation_placeholder(
             format!("\\[Error formatting {cite}\\]")
         });
 
-        tracing::info!(
+        tracing::debug!(
             "Citation replacement ({:?}): '{}' -> '{}'",
             variant,
             cite,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -35,11 +35,11 @@ pub fn detect_format<P: AsRef<Path>>(biblio_file: P) -> BibFormat {
 
     match ext.as_str() {
         "yaml" | "yml" => {
-            tracing::info!("Detected YAML bibliography format");
+            tracing::debug!("Detected YAML bibliography format");
             BibFormat::Yaml
         }
         _ => {
-            tracing::info!("Detected BibTeX bibliography format");
+            tracing::debug!("Detected BibTeX bibliography format");
             BibFormat::BibTeX
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ impl Bibliography {
     ) -> Result<(String, BibFormat), Error> {
         let (bib_content, format) = match &cfg.bibliography {
             Some(biblio_file) => {
-                tracing::info!("Bibliography file: {}", biblio_file);
+                tracing::debug!("Bibliography file: {}", biblio_file);
                 let mut biblio_path = ctx.root.join(&ctx.config.book.src);
                 biblio_path = biblio_path.join(Path::new(&biblio_file));
                 if !biblio_path.exists() {
@@ -107,7 +107,7 @@ impl Preprocessor for Bibliography {
     }
 
     fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> Result<Book, anyhow::Error> {
-        tracing::info!("Processor Name: {}", self.name());
+        tracing::debug!("Processor Name: {}", self.name());
         let book_src_root = ctx.root.join(&ctx.config.book.src);
         let table = match ctx.config.get::<toml::value::Table>("preprocessor.bib") {
             Ok(Some(table)) => Some(table),
@@ -175,11 +175,11 @@ impl Preprocessor for Bibliography {
         // Create the appropriate backend based on configuration
         let backend: Box<dyn crate::backend::BibliographyBackend> = match config.backend {
             BackendMode::Custom => {
-                tracing::info!("Using Custom (Handlebars) backend for rendering");
+                tracing::debug!("Using Custom (Handlebars) backend for rendering");
                 Box::new(CustomBackend::new(&handlebars))
             }
             BackendMode::Csl => {
-                tracing::info!(
+                tracing::debug!(
                     "Using CSL backend with style '{}'",
                     config.csl_style.as_deref().unwrap_or("apa")
                 );
@@ -192,7 +192,7 @@ impl Preprocessor for Bibliography {
         };
 
         tracing::info!("Backend initialized: {}", backend.name());
-        tracing::info!("Citation syntax: {:?}", config.citation_syntax);
+        tracing::debug!("Citation syntax: {:?}", config.citation_syntax);
 
         // First, expand citations to assign indices to BibItems
         let citation_result = citation::expand_cite_references_in_book(

--- a/src/parser/hayagriva_parser.rs
+++ b/src/parser/hayagriva_parser.rs
@@ -13,7 +13,7 @@ pub fn parse_bibliography(
     raw_content: String,
     format: BibFormat,
 ) -> MdResult<IndexMap<String, BibItem>, Error> {
-    tracing::info!(
+    tracing::debug!(
         "🦀 HAYAGRIVA PARSER: Parsing bibliography (format: {:?})...",
         format
     );
@@ -32,7 +32,7 @@ pub fn parse_bibliography(
         .iter()
         .map(|entry| {
             let citation_key = entry.key().to_string();
-            tracing::info!("Processing bibliography entry: {}", citation_key);
+            tracing::debug!("Processing bibliography entry: {}", citation_key);
 
             let title = entry.title().map(format_string_to_text).unwrap_or_else(|| {
                 tracing::warn!(


### PR DESCRIPTION
All of these log messages at `info` (which seems to be the default level for mdbook) make the output of mdbook-bib really spammy.

Reduce most messages to `debug`, as they are irrelevant unless mdbook-bib is not doing what it is supposed to be doing.